### PR TITLE
Adapt to changes in NSUserActivity.Keywords API changes

### DIFF
--- a/src/View Controllers/DetailsViewController.cs
+++ b/src/View Controllers/DetailsViewController.cs
@@ -45,8 +45,8 @@ namespace MonkeySearch
             activity.Title = monkey.Name;
             activity.AddUserInfoEntries(NSDictionary.FromObjectAndKey(new NSString(monkey.Name), new NSString("Name")));
 
-            var keywords = new string[] { monkey.Name, "Monkey" };
-            activity.Keywords = new NSSet(keywords);
+            var keywords = new NSString[] { new NSString(monkey.Name), new NSString("Monkey") };
+            activity.Keywords = new NSSet<NSString>(keywords);
             activity.ContentAttributeSet = new CoreSpotlight.CSSearchableItemAttributeSet(monkey.Details);
 
             return activity;


### PR DESCRIPTION
MonkeySearch-iOS no longer compiles with latest Xamarin.iOS. This PR fixes it.

Error was:

```
View Controllers/DetailsViewController.cs(49,33): error CS0266: Cannot implicitly convert type `Foundation.NSSet' to `Foundation.NSSet<Foundation.NSString>'. An explicit conversion exists (are you missing a cast?)

```
